### PR TITLE
Resolve #1: Add internal models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ MAINTAINER Tim Huegdon <tim@timhuegdon.com>
 ENV PIPENV_SHELL=/bin/bash
 COPY . /app
 WORKDIR /app
-RUN apk add --update --no-cache --virtual=psql-client postgresql-client &&\
-    set -ex && pipenv install --dev --skip-lock                         &&\
+RUN apk add --update --no-cache --virtual=psql-client postgresql-client libffi-dev  &&\
+    set -ex && pipenv install --dev --skip-lock                                     &&\
     rm -rf /root/.cache /var/cache /usr/share/terminfo

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ pytest-cov = "*"
 sphinx = "*"
 
 [packages]
-cerberusauth = {editable = true, path = "."}
+cerberusauth = {editable = true,path = "."}
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,13 +18,89 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:4b6ff7433247fe80b6ef522ef3763acb959cbdef027d03f76f4cd3c7118c1872"
+                "sha256:e9ffdece0eece55f4108b14b6b0f29ffc730d58e28446a434fe41a1cc5c5f266"
             ],
-            "version": "==1.0.3"
+            "version": "==1.0.5"
+        },
+        "bcrypt": {
+            "hashes": [
+                "sha256:01477981abf74e306e8ee31629a940a5e9138de000c6b0898f7f850461c4a0a5",
+                "sha256:054d6e0acaea429e6da3613fcd12d05ee29a531794d96f6ab959f29a39f33391",
+                "sha256:0872eeecdf9a429c1420158500eedb323a132bc5bf3339475151c52414729e70",
+                "sha256:09a3b8c258b815eadb611bad04ca15ec77d86aa9ce56070e1af0d5932f17642a",
+                "sha256:0f317e4ffbdd15c3c0f8ab5fbd86aa9aabc7bea18b5cc5951b456fe39e9f738c",
+                "sha256:2788c32673a2ad0062bea850ab73cffc0dba874db10d7a3682b6f2f280553f20",
+                "sha256:321d4d48be25b8d77594d8324c0585c80ae91ac214f62db9098734e5e7fb280f",
+                "sha256:346d6f84ff0b493dbc90c6b77136df83e81f903f0b95525ee80e5e6d5e4eef84",
+                "sha256:34dd60b90b0f6de94a89e71fcd19913a30e83091c8468d0923a93a0cccbfbbff",
+                "sha256:3b4c23300c4eded8895442c003ae9b14328ae69309ac5867e7530de8bdd7875d",
+                "sha256:43d1960e7db14042319c46925892d5fa99b08ff21d57482e6f5328a1aca03588",
+                "sha256:49e96267cd9be55a349fd74f9852eb9ae2c427cd7f6455d0f1765d7332292832",
+                "sha256:63e06ffdaf4054a89757a3a1ab07f1b922daf911743114a54f7c561b9e1baa58",
+                "sha256:67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d",
+                "sha256:6b662a5669186439f4f583636c8d6ea77cf92f7cfe6aae8d22edf16c36840574",
+                "sha256:6efd9ca20aefbaf2e7e6817a2c6ed4a50ff6900fafdea1bcb1d0e9471743b144",
+                "sha256:8569844a5d8e1fdde4d7712a05ab2e6061343ac34af6e7e3d7935b2bd1907bfd",
+                "sha256:8629ea6a8a59f865add1d6a87464c3c676e60101b8d16ef404d0a031424a8491",
+                "sha256:988cac675e25133d01a78f2286189c1f01974470817a33eaf4cfee573cfb72a5",
+                "sha256:9a6fedda73aba1568962f7543a1f586051c54febbc74e87769bad6a4b8587c39",
+                "sha256:9eced8962ce3b7124fe20fd358cf8c7470706437fa064b9874f849ad4c5866fc",
+                "sha256:a005ed6163490988711ff732386b08effcbf8df62ae93dd1e5bda0714fad8afb",
+                "sha256:ae35dbcb6b011af6c840893b32399252d81ff57d52c13e12422e16b5fea1d0fb",
+                "sha256:b1e8491c6740f21b37cca77bc64677696a3fb9f32360794d57fa8477b7329eda",
+                "sha256:c906bdb482162e9ef48eea9f8c0d967acceb5c84f2d25574c7d2a58d04861df1",
+                "sha256:cb18ffdc861dbb244f14be32c47ab69604d0aca415bee53485fcea4f8e93d5ef",
+                "sha256:cc2f24dc1c6c88c56248e93f28d439ee4018338567b0bbb490ea26a381a29b1e",
+                "sha256:d860c7fff18d49e20339fc6dffc2d485635e36d4b2cccf58f45db815b64100b4",
+                "sha256:d86da365dda59010ba0d1ac45aa78390f56bf7f992e65f70b3b081d5e5257b09",
+                "sha256:e22f0997622e1ceec834fd25947dc2ee2962c2133ea693d61805bc867abaf7ea",
+                "sha256:f2fe545d27a619a552396533cddf70d83cecd880a611cdfdbb87ca6aec52f66b",
+                "sha256:f425e925485b3be48051f913dbe17e08e8c48588fdf44a26b8b14067041c0da6",
+                "sha256:f7fd3ed3745fe6e81e28dc3b3d76cce31525a91f32a387e1febd6b982caf8cdb",
+                "sha256:f9210820ee4818d84658ed7df16a7f30c9fba7d8b139959950acef91745cc0f7"
+            ],
+            "version": "==3.1.4"
         },
         "cerberusauth": {
             "editable": true,
             "path": "."
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
+                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
+                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
+                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
+                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
+                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
+                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
+                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
+                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
+                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
+                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
+                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
+                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
+                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
+                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
+                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
+                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
+                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
+                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
+                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
+                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
+                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
+                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
+                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
+                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
+                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
+                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
+            ],
+            "version": "==1.11.5"
         },
         "mako": {
             "hashes": [
@@ -99,6 +175,12 @@
                 "sha256:ff18c5c40a38d41811c23e2480615425c97ea81fd7e9118b8b899c512d97c737"
             ],
             "version": "==2.7.6.1"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
         },
         "python-dateutil": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -113,6 +113,12 @@
             ],
             "version": "==1.0.3"
         },
+        "python-slugify": {
+            "hashes": [
+                "sha256:7723daf30996db26573176bddcdf5fcb98f66dc70df05c9cb29f2c79b8193245"
+            ],
+            "version": "==1.2.6"
+        },
         "six": {
             "hashes": [
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
@@ -144,6 +150,13 @@
                 "sha256:ba46933fb4575a9a45f74a69572e2ca17988da1f9f5cfbd1eee2c48a1cef5dbc"
             ],
             "version": "==0.33.8"
+        },
+        "unidecode": {
+            "hashes": [
+                "sha256:092cdf7ad9d1052c50313426a625b717dab52f7ac58f859e09ea020953b1ad8f",
+                "sha256:8b85354be8fd0c0e10adbf0675f6dc2310e56fda43fa8fe049123b6c475e52fb"
+            ],
+            "version": "==1.0.23"
         }
     },
     "develop": {

--- a/cerberusauth/__init__.py
+++ b/cerberusauth/__init__.py
@@ -1,7 +1,5 @@
 """
-
 Cerberus - Authentication and authorisation microservice.
-
 """
 
 

--- a/cerberusauth/__version__.py
+++ b/cerberusauth/__version__.py
@@ -1,7 +1,5 @@
 """
-
 Cerberus - Authentication and authorisation microservice.
-
 """
 
 __title__ = 'cerberusauth'

--- a/cerberusauth/models.py
+++ b/cerberusauth/models.py
@@ -16,14 +16,14 @@ class BaseModel(object):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
-        self.created = kwargs.pop('created', datetime.utcnow())
-        self.modified = kwargs.pop('created', self.created)
+        self.created = kwargs.pop("created", datetime.utcnow())
+        self.modified = kwargs.pop("created", self.created)
 
         self._initialised = True
 
     def __setattr__(self, name, value):
         """Global setter."""
-        if not name == 'modified' and self._initialised:
+        if not name == "modified" and self._initialised:
             self.modified = datetime.utcnow()
 
         super(BaseModel, self).__setattr__(name, value)
@@ -32,13 +32,10 @@ class BaseModel(object):
 class User(BaseModel):
     """User model."""
 
-    def __init__(self, email, password, fullname, *args, **kwargs):
+    def __init__(self, email, password=None, fullname=None, *args, **kwargs):
         """Constructor."""
         self.email = email
-        self.password = bcrypt.hashpw(
-            self._encode_password(password),
-            bcrypt.gensalt()
-        )
+        self.password = password
         self.fullname = fullname
 
         super(User, self).__init__(
@@ -49,8 +46,15 @@ class User(BaseModel):
     def _encode_password(password):
         return base64.b64encode(
             hashlib.sha256(
-                password.encode('utf-8')
+                password.encode("utf-8")
             ).digest()
+        )
+
+    def new_password(self, unhashed_password):
+        """Encode and hash a newly created password."""
+        self.password = bcrypt.hashpw(
+            self._encode_password(unhashed_password),
+            bcrypt.gensalt()
         )
 
     def authenticate(self, password):
@@ -67,8 +71,8 @@ class Role(BaseModel):
     def __init__(self, name, *args, **kwargs):
         """Constructor."""
         self.name = name
-        self.description = kwargs.pop('description', None)
-        self.enabled = kwargs.pop('enabled', True)
+        self.description = kwargs.pop("description", None)
+        self.enabled = kwargs.pop("enabled", True)
 
         super(Role, self).__init__(
             *args, **kwargs
@@ -81,8 +85,8 @@ class Permission(BaseModel):
     def __init__(self, slug, *args, **kwargs):
         """Constructor."""
         self.slug = slugify(slug)
-        self.description = kwargs.pop('description', None)
-        self.enabled = kwargs.pop('enabled', True)
+        self.description = kwargs.pop("description", None)
+        self.enabled = kwargs.pop("enabled", True)
 
         super(Permission, self).__init__(
             *args, **kwargs

--- a/cerberusauth/models.py
+++ b/cerberusauth/models.py
@@ -2,6 +2,8 @@
 Models.
 """
 
+from slugify import slugify
+
 
 class User(object):
     """User model."""
@@ -40,7 +42,7 @@ class Permission(object):
 
     def __init__(self, slug, *args, **kwargs):
         """Constructor."""
-        self.slug = slug
+        self.slug = slugify(slug)
         self.description = kwargs.pop('description', None)
         self.enabled = kwargs.pop('enabled', True)
 

--- a/cerberusauth/models.py
+++ b/cerberusauth/models.py
@@ -2,7 +2,10 @@
 Models.
 """
 
+import base64
 from datetime import datetime
+import hashlib
+import bcrypt
 from slugify import slugify
 
 
@@ -32,11 +35,29 @@ class User(BaseModel):
     def __init__(self, email, password, fullname, *args, **kwargs):
         """Constructor."""
         self.email = email
-        self.password = password
+        self.password = bcrypt.hashpw(
+            self._encode_password(password),
+            bcrypt.gensalt()
+        )
         self.fullname = fullname
 
         super(User, self).__init__(
             *args, **kwargs
+        )
+
+    @staticmethod
+    def _encode_password(password):
+        return base64.b64encode(
+            hashlib.sha256(
+                password.encode('utf-8')
+            ).digest()
+        )
+
+    def authenticate(self, password):
+        """Authenticate password matches self.password."""
+        return bcrypt.checkpw(
+            self._encode_password(password),
+            self.password
         )
 
 

--- a/cerberusauth/models.py
+++ b/cerberusauth/models.py
@@ -2,10 +2,32 @@
 Models.
 """
 
+from datetime import datetime
 from slugify import slugify
 
 
-class User(object):
+class BaseModel(object):
+    """Base model."""
+    _initialised = False
+    id = None
+
+    def __init__(self, *args, **kwargs):
+        """Constructor."""
+        self.created = kwargs.pop('created', datetime.utcnow())
+        self.modified = kwargs.pop('created', self.created)
+
+        self._initialised = True
+
+    def __setattr__(self, name, value):
+        """Global setter."""
+        if not name == 'modified':
+            if self._initialised:
+                self.modified = datetime.utcnow()
+
+        super(BaseModel, self).__setattr__(name, value)
+
+
+class User(BaseModel):
     """User model."""
 
     def __init__(self, email, password, fullname, *args, **kwargs):
@@ -14,15 +36,12 @@ class User(object):
         self.password = password
         self.fullname = fullname
 
-        # super(User, self).__init__(
-        #     email=email,
-        #     password=password,
-        #     fullname=fullname,
-        #     *args, **kwargs
-        # )
+        super(User, self).__init__(
+            *args, **kwargs
+        )
 
 
-class Role(object):
+class Role(BaseModel):
     """Role model."""
 
     def __init__(self, name, *args, **kwargs):
@@ -31,13 +50,12 @@ class Role(object):
         self.description = kwargs.pop('description', None)
         self.enabled = kwargs.pop('enabled', True)
 
-        # super(Role, self).__init__(
-        #     name=name,
-        #     *args, **kwargs
-        # )
+        super(Role, self).__init__(
+            *args, **kwargs
+        )
 
 
-class Permission(object):
+class Permission(BaseModel):
     """Permission model."""
 
     def __init__(self, slug, *args, **kwargs):
@@ -46,7 +64,6 @@ class Permission(object):
         self.description = kwargs.pop('description', None)
         self.enabled = kwargs.pop('enabled', True)
 
-        # super(Permission, self).__init__(
-        #     name=name,
-        #     *args, **kwargs
-        # )
+        super(Permission, self).__init__(
+            *args, **kwargs
+        )

--- a/cerberusauth/models.py
+++ b/cerberusauth/models.py
@@ -20,9 +20,8 @@ class BaseModel(object):
 
     def __setattr__(self, name, value):
         """Global setter."""
-        if not name == 'modified':
-            if self._initialised:
-                self.modified = datetime.utcnow()
+        if not name == 'modified' and self._initialised:
+            self.modified = datetime.utcnow()
 
         super(BaseModel, self).__setattr__(name, value)
 

--- a/cerberusauth/models.py
+++ b/cerberusauth/models.py
@@ -1,0 +1,50 @@
+"""
+Models.
+"""
+
+
+class User(object):
+    """User model."""
+
+    def __init__(self, email, password, fullname, *args, **kwargs):
+        """Constructor."""
+        self.email = email
+        self.password = password
+        self.fullname = fullname
+
+        # super(User, self).__init__(
+        #     email=email,
+        #     password=password,
+        #     fullname=fullname,
+        #     *args, **kwargs
+        # )
+
+
+class Role(object):
+    """Role model."""
+
+    def __init__(self, name, *args, **kwargs):
+        """Constructor."""
+        self.name = name
+        self.description = kwargs.pop('description', None)
+        self.enabled = kwargs.pop('enabled', True)
+
+        # super(Role, self).__init__(
+        #     name=name,
+        #     *args, **kwargs
+        # )
+
+
+class Permission(object):
+    """Permission model."""
+
+    def __init__(self, slug, *args, **kwargs):
+        """Constructor."""
+        self.slug = slug
+        self.description = kwargs.pop('description', None)
+        self.enabled = kwargs.pop('enabled', True)
+
+        # super(Permission, self).__init__(
+        #     name=name,
+        #     *args, **kwargs
+        # )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.7"
 services:
   app:
     build: .
+    image: nefarioustim/cerberus-auth
     container_name: app
     depends_on:
       - postgres

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 """
-
 Cerberus - Authentication and authorisation microservice.
-
 """
 
 import os.path

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ with open('LICENSE') as f:
 
 REQUIRED = [
     'alembic',
+    'bcrypt',
     'psycopg2-binary',
     'python-slugify',
     'sqlalchemy',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ with open('LICENSE') as f:
 REQUIRED = [
     'alembic',
     'psycopg2-binary',
+    'python-slugify',
     'sqlalchemy',
     'sqlalchemy-repr',
     'sqlalchemy-utc',

--- a/tests/data_for_tests.py
+++ b/tests/data_for_tests.py
@@ -1,0 +1,34 @@
+"""
+Data for use across tests.
+"""
+
+USER_DICT = {
+    'email': 'joe.bloggs@gmail.com',
+    'password': 'silly password this is',
+    'fullname': 'Joe Bloggs'
+}
+
+ROLE_DICT = {
+    'name': 'Super Admin',
+    'enabled': True
+}
+
+PERMISSION_DICT = {
+    'slug': 'can-test-permissions',
+    'enabled': True
+}
+
+
+def get_user():
+    """Get User dict for testing."""
+    return USER_DICT.copy()
+
+
+def get_role():
+    """Get User dict for testing."""
+    return ROLE_DICT.copy()
+
+
+def get_permission():
+    """Get User dict for testing."""
+    return PERMISSION_DICT.copy()

--- a/tests/test_instantiation.py
+++ b/tests/test_instantiation.py
@@ -1,7 +1,5 @@
 """
-
 Tests for core objects.
-
 """
 
 import cerberusauth

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,6 @@ Tests for models.
 """
 
 from datetime import datetime
-import bcrypt
 import pytest
 
 from cerberusauth import models
@@ -17,8 +16,6 @@ def test_user_model_requires_email_password_fullname():
         models.User()
 
     assert "email" in str(exc.value)
-    assert "password" in str(exc.value)
-    assert "fullname" in str(exc.value)
 
 
 def test_user_model_instantiates():
@@ -28,7 +25,6 @@ def test_user_model_instantiates():
 
     assert user
     assert isinstance(user, models.User)
-    assert user.password != user_dict['password']
     assert user.created is not None
     assert isinstance(user.created, datetime)
     assert user.modified == user.created
@@ -38,12 +34,28 @@ def test_user_model_instantiates():
     assert user.modified > user.created
 
 
+def test_user_model_new_password():
+    """."""
+    user_dict = get_user()
+    user = models.User(**user_dict)
+
+    assert user
+
+    user.new_password(user_dict["password"])
+
+    assert user.password != user_dict["password"]
+    assert user.password.decode()
+
+
 def test_user_model_authenticate():
     """."""
     user_dict = get_user()
     user = models.User(**user_dict)
 
     assert user
+
+    user.new_password(user_dict["password"])
+
     assert user.authenticate(user_dict["password"])
 
 
@@ -94,13 +106,13 @@ def test_permission_model_instantiates():
 
 
 @pytest.mark.parametrize("test_slug, expected_slug", [
-    ('slug', 'slug'),
-    ('random-slug', 'random-slug'),
-    ('randomer/slug', 'randomer-slug'),
-    ('Something Else', 'something-else'),
-    ('___This is a test___', 'this-is-a-test'),
-    ('影師嗎', 'ying-shi-ma'),
-    ('C\'est déjà l\'été.', 'c-est-deja-l-ete')
+    ("slug", "slug"),
+    ("random-slug", "random-slug"),
+    ("randomer/slug", "randomer-slug"),
+    ("Something Else", "something-else"),
+    ("___This is a test___", "this-is-a-test"),
+    ("影師嗎", "ying-shi-ma"),
+    ("C\'est déjà l\'été.", "c-est-deja-l-ete")
 ])
 def test_permission_model_slugifys_slug(test_slug, expected_slug):
     """."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,6 +49,13 @@ def test_role_model_instantiates():
 
     assert role
     assert isinstance(role, models.Role)
+    assert role.created is not None
+    assert isinstance(role.created, datetime)
+    assert role.modified == role.created
+
+    role.id = 1
+
+    assert role.modified > role.created
 
 
 def test_permission_model_requires_slug():
@@ -65,6 +72,13 @@ def test_permission_model_instantiates():
 
     assert permission
     assert isinstance(permission, models.Permission)
+    assert permission.created is not None
+    assert isinstance(permission.created, datetime)
+    assert permission.modified == permission.created
+
+    permission.id = 1
+
+    assert permission.modified > permission.created
 
 
 @pytest.mark.parametrize("test_slug, expected_slug", [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@
 Tests for models.
 """
 
+from datetime import datetime
 import pytest
 
 from cerberusauth import models
@@ -25,6 +26,13 @@ def test_user_model_instantiates():
 
     assert user
     assert isinstance(user, models.User)
+    assert user.created is not None
+    assert isinstance(user.created, datetime)
+    assert user.modified == user.created
+
+    user.id = 1
+
+    assert user.modified > user.created
 
 
 def test_role_model_requires_name():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,59 @@
+"""
+Tests for models.
+"""
+
+import pytest
+
+from cerberusauth import models
+
+from .data_for_tests import get_user, get_role, get_permission
+
+
+def test_user_model_requires_email_password_fullname():
+    """."""
+    with pytest.raises(TypeError) as exc:
+        models.User()
+
+    assert "email" in str(exc.value)
+    assert "password" in str(exc.value)
+    assert "fullname" in str(exc.value)
+
+
+def test_user_model_instantiates():
+    """."""
+    user = models.User(**get_user())
+
+    assert user
+    assert isinstance(user, models.User)
+
+
+def test_role_model_requires_name():
+    """."""
+    with pytest.raises(TypeError) as exc:
+        models.Role()
+
+    assert "name" in str(exc.value)
+
+
+def test_role_model_instantiates():
+    """."""
+    role = models.Role(**get_role())
+
+    assert role
+    assert isinstance(role, models.Role)
+
+
+def test_permission_model_requires_slug():
+    """."""
+    with pytest.raises(TypeError) as exc:
+        models.Permission()
+
+    assert "slug" in str(exc.value)
+
+
+def test_permission_model_instantiates():
+    """."""
+    permission = models.Permission(**get_permission())
+
+    assert permission
+    assert isinstance(permission, models.Permission)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@ Tests for models.
 """
 
 from datetime import datetime
+import bcrypt
 import pytest
 
 from cerberusauth import models
@@ -22,10 +23,12 @@ def test_user_model_requires_email_password_fullname():
 
 def test_user_model_instantiates():
     """."""
-    user = models.User(**get_user())
+    user_dict = get_user()
+    user = models.User(**user_dict)
 
     assert user
     assert isinstance(user, models.User)
+    assert user.password != user_dict['password']
     assert user.created is not None
     assert isinstance(user.created, datetime)
     assert user.modified == user.created
@@ -33,6 +36,15 @@ def test_user_model_instantiates():
     user.id = 1
 
     assert user.modified > user.created
+
+
+def test_user_model_authenticate():
+    """."""
+    user_dict = get_user()
+    user = models.User(**user_dict)
+
+    assert user
+    assert user.authenticate(user_dict["password"])
 
 
 def test_role_model_requires_name():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -57,3 +57,20 @@ def test_permission_model_instantiates():
 
     assert permission
     assert isinstance(permission, models.Permission)
+
+
+@pytest.mark.parametrize("test_slug, expected_slug", [
+    ('slug', 'slug'),
+    ('random-slug', 'random-slug'),
+    ('randomer/slug', 'randomer-slug'),
+    ('Something Else', 'something-else'),
+    ('___This is a test___', 'this-is-a-test'),
+    ('影師嗎', 'ying-shi-ma'),
+    ('C\'est déjà l\'été.', 'c-est-deja-l-ete')
+])
+def test_permission_model_slugifys_slug(test_slug, expected_slug):
+    """."""
+    permission = models.Permission(slug=test_slug)
+
+    assert permission
+    assert permission.slug == expected_slug


### PR DESCRIPTION
This change creates internal base models for:

- User
- Role
- Permission

All models inherit `created` and `modified` UTC datetime fields from `BaseModel`, and an `id` field which can be populated when passed back by any storage method.

The `User` model also allows hashing of a new password value, and provides an `authenticate` method that returns a boolean value.

The intention is that storage specific models, such as those for SQLAlchemy, can derive from these models and override fields and features where necessary.