### PR TITLE
Resolve #3: Speed up CI build by using prebuilt Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: python
 
 services: docker
 
-before_install: docker build -t cerberusauth .
+before_install: docker pull nefarioustim/cerberusauth
 
 install: true
 
-script: docker run cerberusauth pipenv run pytest
+script: docker run nefarioustim/cerberusauth pipenv run pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: python
 
 services: docker
 
-before_install: docker pull nefarioustim/cerberusauth
+before_install: docker pull nefarioustim/cerberus-auth
 
 install: true
 
-script: docker run nefarioustim/cerberusauth pipenv run pytest
+script: docker run nefarioustim/cerberus-auth pipenv run pytest


### PR DESCRIPTION
This change ensures the Travis configuration uses the prebuilt `nefarioustim/cerberus-auth` Docker image found at https://hub.docker.com/r/nefarioustim/cerberus-auth/

As a result, build has gone from **~2 min** to **~30 sec**.