### PR TITLE
Resolve #8: Add a logging handler

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -201,6 +201,22 @@
             ],
             "version": "==1.2.6"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+            ],
+            "version": "==3.13"
+        },
         "six": {
             "hashes": [
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
@@ -272,9 +288,9 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c"
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
             ],
-            "version": "==2018.10.15"
+            "version": "==2018.11.29"
         },
         "chardet": {
             "hashes": [

--- a/cerberusauth/config.py
+++ b/cerberusauth/config.py
@@ -1,0 +1,15 @@
+"""
+Core configuration for Cerberus.
+
+Any values included in here should be configurable as an environment variable,
+so that the service is configurable without code release.
+"""
+
+import os
+
+
+_config_path = os.path.dirname(os.path.realpath(__file__))
+
+LOGGING_CONFIG_FILE = os.getenv(
+    "LOGGING_CONFIG_FILE", os.path.join(_config_path, "logging.yml")
+)

--- a/cerberusauth/logger.py
+++ b/cerberusauth/logger.py
@@ -1,0 +1,28 @@
+"""
+Logging set-up for Cerberus.
+"""
+
+import os
+import logging.config
+
+import yaml
+
+from . import config
+
+
+def setup_logging(
+    config_path=config.LOGGING_CONFIG_FILE
+):
+    """Setup logging configuration."""
+    if os.path.exists(config_path):
+        with open(config_path, 'rt') as f:
+            logging_config = yaml.safe_load(f.read())
+
+        logging.config.dictConfig(logging_config)
+        message = "Logging setup from {}.".format(config_path)
+
+    else:
+        logging.basicConfig(level="INFO")
+        message = "Logging setup with basicConfig."
+
+    logging.getLogger(__name__).info(message)

--- a/cerberusauth/logger.py
+++ b/cerberusauth/logger.py
@@ -13,7 +13,21 @@ from . import config
 def setup_logging(
     config_path=config.LOGGING_CONFIG_FILE
 ):
-    """Setup logging configuration."""
+    """
+    Setup logging configuration, to be called on initilisation of application.
+
+    This will attempt to set-up logging based on the configuration file
+    logging.yml. This configuration can be overridden by passing the path to a
+    similar YAML file as the ENV variable LOGGING_CONFIG_FILE.
+
+    Once set-up, the rest of the microservice can simply create a logging
+    instance as normal, with::
+
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+    """
     if os.path.exists(config_path):
         with open(config_path, 'rt') as f:
             logging_config = yaml.safe_load(f.read())

--- a/cerberusauth/logging.yml
+++ b/cerberusauth/logging.yml
@@ -1,0 +1,36 @@
+---
+version: 1
+
+formatters:
+    simple:
+        format: "%(asctime)s - %(levelname)-8s - %(name)s - %(message)s"
+        datefmt: "%Y-%m-%d %H:%M:%S"
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        formatter: simple
+        level: INFO
+
+    info_file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: INFO
+        formatter: simple
+        filename: "/var/log/cerberusinfo.log"
+        encoding: utf-8
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+
+    error_file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: ERROR
+        formatter: simple
+        filename: "/var/log/cerberuserror.log"
+        encoding: utf-8
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+
+loggers:
+    root:
+        level: INFO
+        handlers: [console, info_file_handler, error_file_handler]

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ REQUIRED = [
     'bcrypt',
     'psycopg2-binary',
     'python-slugify',
+    'pyyaml',
     'sqlalchemy',
     'sqlalchemy-repr',
     'sqlalchemy-utc',

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,21 @@
+"""
+Tests for logging setup.
+"""
+
+from cerberusauth import logger
+
+
+def test_setup_logging(caplog):
+    """."""
+    with caplog.at_level("INFO"):
+        logger.setup_logging()
+
+    assert "Logging setup from /app/cerberusauth/logging.yml." in caplog.text
+
+
+def test_setup_logging_with_bad_config(caplog):
+    """."""
+    with caplog.at_level("INFO"):
+        logger.setup_logging("geoff")
+
+    assert "Logging setup with basicConfig." in caplog.text


### PR DESCRIPTION
This change provides logging setup for the microservice.

On initialisation, the service should call:

```python
logger.setup_logging()
```

This will attempt to set-up `logging` based on the configuration file `logging.yml`. This configuration can be overridden by passing the path to a similar YAML file as the ENV variable `LOGGING_CONFIG_FILE`.

Once set-up, the rest of the microservice can simply create a `logging` instance as normal, with:

```python
import logging

logger = logging.getLogger(__name__)
```