### PR TITLE
Resolve #5: Add SQLAlchemy models

### DIFF
--- a/cerberusauth/base.py
+++ b/cerberusauth/base.py
@@ -2,21 +2,8 @@
 Base code for models.
 """
 
-from datetime import datetime
 import logging
-
-
-class BaseModel(object):
-    """Base model."""
-    _initialised = False
-    id = None
-
-    def __init__(self, *args, **kwargs):
-        """Constructor."""
-        self.created = kwargs.pop("created", datetime.utcnow())
-        self.modified = kwargs.pop("modified", self.created)
-
-        self._initialised = True
+from models import BaseModel
 
 
 class BaseRepository(object):

--- a/cerberusauth/models/__init__.py
+++ b/cerberusauth/models/__init__.py
@@ -2,12 +2,21 @@
 Models.
 """
 
+from datetime import datetime
 import base64
 import hashlib
 import bcrypt
 from slugify import slugify
 
-from ..base import BaseModel
+
+class BaseModel(object):
+    """Base model."""
+    id = None
+
+    def __init__(self, *args, **kwargs):
+        """Constructor."""
+        self.created = kwargs.pop("created", datetime.utcnow())
+        self.modified = kwargs.pop("modified", self.created)
 
 
 class User(BaseModel):
@@ -19,9 +28,7 @@ class User(BaseModel):
         self.password = password
         self.fullname = fullname
 
-        super(User, self).__init__(
-            *args, **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def _encode_password(password):
@@ -55,9 +62,7 @@ class Role(BaseModel):
         self.description = kwargs.pop("description", None)
         self.enabled = kwargs.pop("enabled", True)
 
-        super(Role, self).__init__(
-            *args, **kwargs
-        )
+        super().__init__(*args, **kwargs)
 
 
 class Permission(BaseModel):
@@ -69,6 +74,4 @@ class Permission(BaseModel):
         self.description = kwargs.pop("description", None)
         self.enabled = kwargs.pop("enabled", True)
 
-        super(Permission, self).__init__(
-            *args, **kwargs
-        )
+        super().__init__(*args, **kwargs)

--- a/cerberusauth/models/sqlalchemy.py
+++ b/cerberusauth/models/sqlalchemy.py
@@ -1,0 +1,52 @@
+"""
+SQLAlchemy Models.
+"""
+
+from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy_repr import RepresentableBase
+from sqlalchemy_utc import UtcDateTime, utcnow
+
+from . import User as BaseUser, Role as BaseRole, Permission as BasePermission
+
+
+class BaseSQLModel(RepresentableBase):
+    """Base model for SQLAlchemy."""
+    id = Column('id', Integer, primary_key=True)
+    created = Column(UtcDateTime, default=utcnow())
+    modified = Column(UtcDateTime, onupdate=utcnow())
+
+BaseSQLModel = declarative_base(cls=BaseSQLModel)
+
+
+class User(BaseSQLModel, BaseUser):
+    """User model for SQLAlchemy."""
+    __tablename__ = 'user'
+
+    email = Column(String(255), nullable=False)
+    password = Column(String(255), nullable=False)
+    fullname = Column(String(255))
+
+    __init__ = BaseUser.__init__
+
+
+class Role(BaseSQLModel, BaseRole):
+    """Role model for SQLAlchemy."""
+    __tablename__ = 'role'
+
+    name = Column(String(255), nullable=False)
+    description = Column(String(255))
+    enabled = Column(Boolean())
+
+    __init__ = BaseRole.__init__
+
+
+class Permission(BaseSQLModel, BasePermission):
+    """Permission model for SQLAlchemy."""
+    __tablename__ = 'permission'
+
+    slug = Column(String(255), nullable=False)
+    description = Column(String(255))
+    enabled = Column(Boolean())
+
+    __init__ = BasePermission.__init__

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -1,0 +1,114 @@
+"""
+Tests for models.
+"""
+
+from datetime import datetime
+import pytest
+
+from .data_for_tests import get_user, get_role, get_permission
+
+
+def assert_object_matches_dict(obj, dic):
+    """Assert object properties match dict keys."""
+    for (key, value) in dic.items():
+        assert getattr(obj, key) == value
+
+
+def test_user_model_requires_email_password_fullname(models):
+    """."""
+    with pytest.raises(TypeError) as exc:
+        models.User()
+
+    assert "email" in str(exc.value)
+
+
+def test_user_model_instantiates(models):
+    """."""
+    user_dict = get_user()
+    user = models.User(**user_dict)
+
+    assert user
+    assert isinstance(user, models.User)
+    assert user.created is not None
+    assert user.modified == user.created
+    assert_object_matches_dict(user, user_dict)
+
+
+def test_user_model_new_password(models):
+    """."""
+    user_dict = get_user()
+    user = models.User(**user_dict)
+
+    assert user
+
+    user.new_password(user_dict["password"])
+
+    assert user.password != user_dict["password"]
+    assert user.password.decode()
+
+
+def test_user_model_authenticate(models):
+    """."""
+    user_dict = get_user()
+    user = models.User(**user_dict)
+
+    assert user
+
+    user.new_password(user_dict["password"])
+
+    assert user.authenticate(user_dict["password"])
+
+
+def test_role_model_requires_name(models):
+    """."""
+    with pytest.raises(TypeError) as exc:
+        models.Role()
+
+    assert "name" in str(exc.value)
+
+
+def test_role_model_instantiates(models):
+    """."""
+    role = models.Role(**get_role())
+
+    assert role
+    assert isinstance(role, models.Role)
+    assert role.created is not None
+    assert isinstance(role.created, datetime)
+    assert role.modified == role.created
+
+
+def test_permission_model_requires_slug(models):
+    """."""
+    with pytest.raises(TypeError) as exc:
+        models.Permission()
+
+    assert "slug" in str(exc.value)
+
+
+def test_permission_model_instantiates(models):
+    """."""
+    permission = models.Permission(**get_permission())
+
+    assert permission
+    assert isinstance(permission, models.Permission)
+    assert permission.created is not None
+    assert isinstance(permission.created, datetime)
+    assert permission.modified == permission.created
+
+
+@pytest.mark.parametrize("test_slug, expected_slug", [
+    ("slug", "slug"),
+    ("random-slug", "random-slug"),
+    ("randomer/slug", "randomer-slug"),
+    ("Something Else", "something-else"),
+    ("___This is a test___", "this-is-a-test"),
+    ("影師嗎", "ying-shi-ma"),
+    ("C\'est déjà l\'été.", "c-est-deja-l-ete")
+])
+def test_permission_model_slugifys_slug(models, test_slug, expected_slug):
+    """."""
+    permission = models.Permission(slug=test_slug)
+
+    assert permission
+    assert permission.slug == expected_slug

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,109 +2,14 @@
 Tests for models.
 """
 
-from datetime import datetime
 import pytest
 
-from cerberusauth import models
+from cerberusauth import models as base_models
 
-from .data_for_tests import get_user, get_role, get_permission
-
-
-def test_user_model_requires_email_password_fullname():
-    """."""
-    with pytest.raises(TypeError) as exc:
-        models.User()
-
-    assert "email" in str(exc.value)
+from .model_tests import *
 
 
-def test_user_model_instantiates():
-    """."""
-    user_dict = get_user()
-    user = models.User(**user_dict)
-
-    assert user
-    assert isinstance(user, models.User)
-    assert user.created is not None
-    assert isinstance(user.created, datetime)
-    assert user.modified == user.created
-
-
-def test_user_model_new_password():
-    """."""
-    user_dict = get_user()
-    user = models.User(**user_dict)
-
-    assert user
-
-    user.new_password(user_dict["password"])
-
-    assert user.password != user_dict["password"]
-    assert user.password.decode()
-
-
-def test_user_model_authenticate():
-    """."""
-    user_dict = get_user()
-    user = models.User(**user_dict)
-
-    assert user
-
-    user.new_password(user_dict["password"])
-
-    assert user.authenticate(user_dict["password"])
-
-
-def test_role_model_requires_name():
-    """."""
-    with pytest.raises(TypeError) as exc:
-        models.Role()
-
-    assert "name" in str(exc.value)
-
-
-def test_role_model_instantiates():
-    """."""
-    role = models.Role(**get_role())
-
-    assert role
-    assert isinstance(role, models.Role)
-    assert role.created is not None
-    assert isinstance(role.created, datetime)
-    assert role.modified == role.created
-
-
-def test_permission_model_requires_slug():
-    """."""
-    with pytest.raises(TypeError) as exc:
-        models.Permission()
-
-    assert "slug" in str(exc.value)
-
-
-def test_permission_model_instantiates():
-    """."""
-    permission = models.Permission(**get_permission())
-
-    assert permission
-    assert isinstance(permission, models.Permission)
-    assert permission.created is not None
-    assert isinstance(permission.created, datetime)
-    assert permission.modified == permission.created
-
-
-@pytest.mark.parametrize("test_slug, expected_slug", [
-    ("slug", "slug"),
-    ("random-slug", "random-slug"),
-    ("randomer/slug", "randomer-slug"),
-    ("Something Else", "something-else"),
-    ("___This is a test___", "this-is-a-test"),
-    ("影師嗎", "ying-shi-ma"),
-    ("C\'est déjà l\'été.", "c-est-deja-l-ete")
-])
-def test_permission_model_slugifys_slug(test_slug, expected_slug):
-    """."""
-    permission = models.Permission(slug=test_slug)
-
-    assert permission
-    assert permission.slug == expected_slug
+@pytest.fixture
+def models():
+    """Models fixture."""
+    return base_models

--- a/tests/test_models_sqlalchemy.py
+++ b/tests/test_models_sqlalchemy.py
@@ -1,0 +1,36 @@
+"""
+Tests for SQLAlchemy models.
+"""
+
+import pytest
+
+from sqlalchemy.orm.base import object_mapper
+
+from cerberusauth.models import sqlalchemy as sqlalchemy_models
+
+from .data_for_tests import get_user, get_role, get_permission
+from .model_tests import *
+
+
+@pytest.fixture
+def models():
+    """Models fixture."""
+    return sqlalchemy_models
+
+
+def test_user_model_can_object_map_for_sql_alchemy(models):
+    """."""
+    # Raises exception if not ORM model.
+    object_mapper(models.User(**get_user()))
+
+
+def test_role_model_can_object_map_for_sql_alchemy(models):
+    """."""
+    # Raises exception if not ORM model.
+    object_mapper(models.Role(**get_role()))
+
+
+def test_permission_model_can_object_map_for_sql_alchemy(models):
+    """."""
+    # Raises exception if not ORM model.
+    object_mapper(models.Permission(**get_permission()))


### PR DESCRIPTION
This change adds SQLAlchemy models for storage, in accordance with #5.

I have refactored the tests to allow reuse for the newly derived models, and I have slightly restructured the model code so that BaseModel is alongside the core models again.