### PR TITLE
Add namespace property to Role and Permission models.

### DIFF
--- a/src/cerberusauth/models/__init__.py
+++ b/src/cerberusauth/models/__init__.py
@@ -106,6 +106,9 @@ class BaseRole(BaseModel):
         self.name = name
         self.description = kwargs.pop("description", None)
 
+        namespace = kwargs.pop("namespace", None)
+        self.namespace = slugify(namespace) if namespace else None
+
         super().__init__(*args, **kwargs)
 
 
@@ -116,5 +119,8 @@ class BasePermission(BaseModel):
         """Constructor."""
         self.slug = slugify(slug)
         self.description = kwargs.pop("description", None)
+
+        namespace = kwargs.pop("namespace", None)
+        self.namespace = slugify(namespace) if namespace else None
 
         super().__init__(*args, **kwargs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,8 @@ Tests for models.
 
 import pytest
 
+from slugify import slugify
+
 from cerberusauth import models as model_factories
 
 from .data_for_tests import get_user, get_role, get_permission
@@ -94,6 +96,20 @@ def test_role_model_instantiates(role):
     assert_instantiation(role, get_role())
 
 
+@pytest.mark.parametrize("test_ns, expected_ns", [
+    ("Wyrd Technology", "wyrd-technology"),
+    ("___This is a test___", "this-is-a-test"),
+    (None, None),
+    (False, None)
+])
+def test_role_model_namespace(role, test_ns, expected_ns):
+    """."""
+    role = role(namespace=test_ns, **get_role())
+
+    assert role
+    assert role.namespace == expected_ns
+
+
 def test_permission_model_requires_slug(permission):
     """."""
     with pytest.raises(TypeError) as exc:
@@ -105,6 +121,20 @@ def test_permission_model_requires_slug(permission):
 def test_permission_model_instantiates(permission):
     """."""
     assert_instantiation(permission, get_permission())
+
+
+@pytest.mark.parametrize("test_ns, expected_ns", [
+    ("Wyrd Technology", "wyrd-technology"),
+    ("___This is a test___", "this-is-a-test"),
+    (None, None),
+    (False, None)
+])
+def test_permission_model_namespace(permission, test_ns, expected_ns):
+    """."""
+    permission = permission(namespace=test_ns, **get_permission())
+
+    assert permission
+    assert permission.namespace == expected_ns
 
 
 @pytest.mark.parametrize("test_slug, expected_slug", [


### PR DESCRIPTION
Allows localisation of Role and Permission to a given namespace, to allow namespace-specific roles
and permissions.

Resolves #19.