### PR TITLE
Add AuthoriseService

### DIFF
--- a/src/cerberusauth/__init__.py
+++ b/src/cerberusauth/__init__.py
@@ -2,6 +2,7 @@
 Cerberus - Authentication and authorisation microservice.
 """
 
+from . import authorise
 from . import config
 from . import register
 from . import schema
@@ -35,6 +36,8 @@ class CerberusAuth(object):
 
     def _setup_services(self):
         """Setup services with self.storage_session."""
+        self.authorise = authorise.create_authorise_service(
+            session=self.storage_session)
         self.register = register.create_register_service(
             session=self.storage_session)
 

--- a/src/cerberusauth/authorise/__init__.py
+++ b/src/cerberusauth/authorise/__init__.py
@@ -1,0 +1,18 @@
+"""
+Module containing core functionality for the authorisation application service.
+"""
+
+import logging
+
+
+def create_authorise_service(session=None, logger=None):
+    """RegisterService factory."""
+    logger = logger or logging.getLogger(__name__)
+    return AuthoriseService()
+
+
+class AuthoriseService(object):
+    """
+    An application service that controls all aspects of authorisation.
+    """
+    pass

--- a/tests/test_authorise_service.py
+++ b/tests/test_authorise_service.py
@@ -7,7 +7,7 @@ from cerberusauth import authorise
 
 def test_create_authorise_service():
     """."""
-    auth = authorise.create_register_service()
+    auth = authorise.create_authorise_service()
 
     assert auth
     assert isinstance(auth, authorise.AuthoriseService)

--- a/tests/test_authorise_service.py
+++ b/tests/test_authorise_service.py
@@ -1,0 +1,13 @@
+"""
+Tests for AuthoriseService.
+"""
+
+from cerberusauth import authorise
+
+
+def test_create_authorise_service():
+    """."""
+    auth = authorise.create_register_service()
+
+    assert auth
+    assert isinstance(auth, authorise.AuthoriseService)

--- a/tests/test_cerberusauth.py
+++ b/tests/test_cerberusauth.py
@@ -14,6 +14,7 @@ def test_cerberus():
     assert cerberus
     assert isinstance(cerberus, cerberusauth.CerberusAuth)
     assert cerberus.register
+    assert cerberus.authorise
 
 
 def test_create_schema(monkeypatch):


### PR DESCRIPTION
This change resolves #37 by adding the `AuthoriseService` as `CerberusAuth.authorise`.