### PR TITLE
Allow adding of new roles

### DIFF
--- a/src/cerberusauth/authorise/command.py
+++ b/src/cerberusauth/authorise/command.py
@@ -4,7 +4,7 @@ Authorisation commands for CerberusAuth.
 
 import logging
 from .. import filters
-from ..repository import permission
+from ..repository import permission, role
 
 
 def create_new_permissions_command(session=None, logger=None):
@@ -44,3 +44,42 @@ class NewPermissionsCommand(object):
         )
 
         return permissions
+
+
+def create_new_roles_command(session=None, logger=None):
+    """NewRolesCommand factory."""
+    logger = logger or logging.getLogger(__name__)
+    return NewRolesCommand(
+        role_repository=role.get_repository(
+            session=session, logger=logger),
+        logger=logger
+    )
+
+
+class NewRolesCommand(object):
+    """Command for creating new Role(s)."""
+
+    def __init__(self, role_repository, logger=None):
+        """Initialise an instance."""
+        self.role_repository = role_repository
+        self.logger = logger
+
+    def __call__(self, *role_dicts):
+        """Add multiple roles from @role_dicts."""
+        filtered_role_dicts = [
+            filters.filter_role_dict(role_dict)
+            for role_dict in role_dicts
+            if filters.filter_role_dict(role_dict)
+        ]
+
+        roles = self.role_repository.save(
+            *filtered_role_dicts)
+
+        self.logger.info(
+            "Registered {} new Role(s): {}".format(
+                len(filtered_role_dicts),
+                ', '.join([r.name for r in roles if r])
+            )
+        )
+
+        return roles

--- a/src/cerberusauth/filters.py
+++ b/src/cerberusauth/filters.py
@@ -46,3 +46,8 @@ def filter_user_dict(user_dict):
 def filter_permission_dict(permission_dict):
     """Filter @permission_dict based on models.BasePermission."""
     return filter_model_dict(models.BasePermission, permission_dict)
+
+
+def filter_role_dict(role_dict):
+    """Filter @role_dict based on models.BaseRole."""
+    return filter_model_dict(models.BaseRole, role_dict)

--- a/tests/test_authorise_command.py
+++ b/tests/test_authorise_command.py
@@ -41,3 +41,39 @@ def test_new_permissions_command(
 
     assert isinstance(permissions, list)
     assert len(permissions) == expected_count
+
+
+def test_create_new_roles_command():
+    """."""
+    new_roles = command.create_new_roles_command()
+
+    assert new_roles
+    assert isinstance(new_roles, command.NewRolesCommand)
+    assert callable(new_roles)
+
+
+@pytest.mark.parametrize("list_of_dicts, expected_count", [
+    ([{"name": "Admin"}], 1),
+    ([
+        {"name": "Admin"},
+        True
+    ], 1),
+    ([
+        "NO, JEFF!",
+        {"id": "test", "fullname": "Joe Bloggs"},
+        False
+    ], 0)
+])
+def test_new_roles_command(
+    caplog, storage_session, list_of_dicts, expected_count
+):
+    """."""
+    new_roles = command.create_new_roles_command(
+        session=storage_session
+    )
+
+    with caplog.at_level("INFO"):
+        roles = new_roles(*list_of_dicts)
+
+    assert isinstance(roles, list)
+    assert len(roles) == expected_count

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -48,3 +48,25 @@ def test_filter_permission_dict(permission_dict, expected):
     filtered = filters.filter_permission_dict(permission_dict)
 
     assert filtered == expected
+
+
+@pytest.mark.parametrize("role_dict, expected", ((
+    {'name': 'Admin'}, {'name': 'Admin'}
+), (
+    {'name': 'Admin', 'description': 'For administrators'},
+    {'name': 'Admin', 'description': 'For administrators'}
+), (
+    {'description': 'Wonky Donky'},
+    False
+), (
+    True,
+    False
+), (
+    "Geoffrey!",
+    False
+)))
+def test_filter_role_dict(role_dict, expected):
+    """."""
+    filtered = filters.filter_role_dict(role_dict)
+
+    assert filtered == expected


### PR DESCRIPTION
This change resolves #21 by providing `NewRoleCommand` on `CerberusAuth.authorise`.