### PR TITLE
Add many-to-many relationships between models

### DIFF
--- a/e2etests/test_e2e.py
+++ b/e2etests/test_e2e.py
@@ -5,7 +5,7 @@ E2E tests.
 from sqlalchemy.inspection import inspect
 from cerberusauth.schema import sql as sqlschema
 
-EXPECTED_MODELS = ['user', 'role', 'permission']
+EXPECTED_MODELS = ['user', 'role', 'userrole', 'permission', 'rolepermission']
 
 
 def test_schema_creation(cerberus_fixture):

--- a/src/cerberusauth/models/sql.py
+++ b/src/cerberusauth/models/sql.py
@@ -2,7 +2,8 @@
 SQLAlchemy Models.
 """
 
-from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy import Table, Column, Integer, String, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy_utc import UtcDateTime, utcnow
 
@@ -20,6 +21,20 @@ class BaseSQLModel(object):
 BaseSQLModel = declarative_base(cls=BaseSQLModel)
 
 
+user_role = Table(
+    'userrole', BaseSQLModel.metadata,
+    Column('user_id', Integer, ForeignKey('user.id')),
+    Column('role_id', Integer, ForeignKey('role.id'))
+)
+
+
+role_permission = Table(
+    'rolepermission', BaseSQLModel.metadata,
+    Column('role_id', Integer, ForeignKey('role.id')),
+    Column('permission_id', Integer, ForeignKey('permission.id'))
+)
+
+
 class User(BaseSQLModel, BaseUser):
     """User model for SQLAlchemy."""
     __tablename__ = 'user'
@@ -27,6 +42,11 @@ class User(BaseSQLModel, BaseUser):
     email = Column(String(255), nullable=False)
     password = Column(String(255), nullable=False)
     fullname = Column(String(255))
+
+    roles = relationship(
+        "Role",
+        secondary=user_role,
+        back_populates="users")
 
     __init__ = BaseUser.__init__
 
@@ -38,6 +58,15 @@ class Role(BaseSQLModel, BaseRole):
     name = Column(String(255), nullable=False)
     description = Column(String(255))
 
+    users = relationship(
+        "User",
+        secondary=user_role,
+        back_populates="roles")
+    permissions = relationship(
+        "Permission",
+        secondary=role_permission,
+        back_populates="roles")
+
     __init__ = BaseRole.__init__
 
 
@@ -47,5 +76,10 @@ class Permission(BaseSQLModel, BasePermission):
 
     slug = Column(String(255), nullable=False)
     description = Column(String(255))
+
+    roles = relationship(
+        "Role",
+        secondary=role_permission,
+        back_populates="permissions")
 
     __init__ = BasePermission.__init__


### PR DESCRIPTION
Also provide parent and child collections within the models, as a method to access further models.

Resolves #43.